### PR TITLE
Status badge, and also test on master and releases

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,11 @@
 name: Test
 
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - master
+      - releases/*
 
 jobs:
   lint-test:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # *Kind* Action
 
+[![](https://github.com/helm/kind-action/workflows/Test/badge.svg?branch=master)](https://github.com/helm/kind-action/actions)
+
 A GitHub Action for Kubernetes IN Docker - local clusters for testing Kubernetes using [kubernetes-sigs/kind](https://kind.sigs.k8s.io/).
 
 ## Usage


### PR DESCRIPTION
Now that we have tests (https://github.com/helm/kind-action/pull/12 we can add a status badge.

In order to ensure status badge is up to date we should also test on master and releases.