### PR TITLE
Actions trigger syntax cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,9 @@ on:
   push:
     branches:
       - master
-      - releases/*
+  release:
+    types:
+      - created
 
 jobs:
   lint-test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - master
-  release:
-    types:
-      - created
 
 jobs:
   lint-test:


### PR DESCRIPTION
Not sure if we really need to test on releases, but may be a good idea? If so, this fixes the syntax per https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#release-event-release. If we don't want this, we can just remove the `- releases/*` branch pattern matching.