### PR TITLE
update kind to 0.7.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: Test
         run: |
           kubectl cluster-info
-          kubectl get storageclass local-path
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: Test
         run: |
           kubectl cluster-info
-
+          kubectl get storageclass standard

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Create kind cluster
         uses: ./
-        with:
-          install_local_path_provisioner: true
 
       - name: Test
         run: |

--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 
 For more information on inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input)
 
-- `version`: The kind version to use (default: `v0.6.1`)
+- `version`: The kind version to use (default: `v0.7.0`)
 - `config`: The path to the kind config file
 - `node_image`: The Docker image for the cluster nodes
 - `cluster_name`: The name of the cluster to create (default: `chart-testing`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for kind
 - `install_local_path_provisioner`: If true, Rancher's local-path provisioner is installed which supports dynamic volume provisioning on multi-node clusters.
-  The newly created local-path StorageClass is made the default.
 
 ### Example Workflow
 
@@ -39,8 +38,6 @@ jobs:
     steps:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.0.0-alpha.3
-        with:
-          install_local_path_provisioner: true
 ```
 
 This uses [@helm/kind-action](https://www.github.com/helm/kind-action) GitHub Action to spin up a [kind](https://kind.sigs.k8s.io/) Kubernetes cluster on every Pull Request.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `cluster_name`: The name of the cluster to create (default: `chart-testing`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for kind
-- `install_local_path_provisioner`: If true, Rancher's local-path provisioner is installed which supports dynamic volume provisioning on multi-node clusters.
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,6 @@ inputs:
     description: "The duration to wait for the control plane to become ready (default: 60s)"
   log_level:
     description: "The log level for kind"
-  install_local_path_provisioner:
-    description: |
-      If true, Rancher's local-path provisioner is installed which supports
-      dynamic volume provisioning on multi-node clusters.
 runs:
   using: "node12"
   main: "main.js"

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: box
 inputs:
   version:
-    description: "The kind version to use (default: v0.6.1)"
+    description: "The kind version to use (default: v0.7.0)"
   config:
     description: "The path to the kind config file"
   node_image:
@@ -20,8 +20,7 @@ inputs:
   install_local_path_provisioner:
     description: |
       If true, Rancher's local-path provisioner is installed which supports
-      dynamic volume provisioning on multi-node clusters. The newly created
-      local-path StorageClass is made the default.
+      dynamic volume provisioning on multi-node clusters. 
 runs:
   using: "node12"
   main: "main.js"

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   install_local_path_provisioner:
     description: |
       If true, Rancher's local-path provisioner is installed which supports
-      dynamic volume provisioning on multi-node clusters. 
+      dynamic volume provisioning on multi-node clusters.
 runs:
   using: "node12"
   main: "main.js"

--- a/kind.sh
+++ b/kind.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DEFAULT_KIND_VERSION=v0.6.1
+DEFAULT_KIND_VERSION=v0.7.0
 DEFAULT_CLUSTER_NAME=chart-testing
 KUBECTL_VERSION=v1.17.0
 
@@ -27,15 +27,14 @@ cat << EOF
 Usage: $(basename "$0") <options>
 
     -h, --help                              Display help
-    -v, --version                           The kind version to use (default: v0.6.1)"
+    -v, --version                           The kind version to use (default: v0.7.0)"
     -c, --config                            The path to the kind config file"
     -i, --node-image                        The Docker image for the cluster nodes"
     -n, --cluster-name                      The name of the cluster to create (default: chart-testing)"
     -w, --wait                              The duration to wait for the control plane to become ready (default: 60s)"
     -l, --log-level                         The log level for kind [panic, fatal, error, warning, info, debug, trace] (default: warning)
     -p, --install-local-path-provisioner    If true, Rancher's local-path provisioner is installed which supports
-                                            dynamic volume provisioning on multi-node clusters. The newly created
-                                            local-path StorageClass is made the default.
+                                            dynamic volume provisioning on multi-node clusters.
 
 EOF
 }
@@ -55,7 +54,7 @@ main() {
     install_kubectl
     create_kind_cluster
 
-    if [[ -n "$install_local_path_provisioner" ]]; then
+    if [[ "$install_local_path_provisioner" == "true" ]]; then
         install_local_path_provisioner
     fi
 }
@@ -128,7 +127,14 @@ parse_command_line() {
                 fi
                 ;;
             -p|--install-local-path-provisioner)
-                install_local_path_provisioner=true
+                if [[ -n "${2:-}" ]]; then
+                   install_local_path_provisioner="$2"
+                   shift
+                else
+                    echo "ERROR: '--install-local-path-provisioner' cannot be empty." >&2
+                    show_help
+                    exit 1
+                fi
                 ;;
             *)
                 break

--- a/main.sh
+++ b/main.sh
@@ -47,10 +47,6 @@ main() {
         args+=(--log-level "${INPUT_LOG_LEVEL}")
     fi
 
-    if [[ -n "${INPUT_INSTALL_LOCAL_PATH_PROVISIONER:-}" ]]; then
-        args+=(--install-local-path-provisioner)
-    fi
-
     "$SCRIPT_DIR/kind.sh" "${args[@]}"
 }
 


### PR DESCRIPTION
fixes not running kind jobs where the charts use persistence. 

For example: 
* https://github.com/eclipse/packages/pull/18
* https://github.com/elastic/helm-charts/issues/429

Kind fixed it by: https://github.com/kubernetes-sigs/kind/pull/1157 which is in release 0.7.0