### PR TITLE
Add registry feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,3 +36,44 @@ jobs:
         run: |
           kubectl cluster-info
           kubectl get storageclass standard
+
+  test-with-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Create kind cluster with registry
+        uses: ./
+        with:
+          registry: true
+
+      - name: Test
+        run: |
+          kubectl cluster-info
+          kubectl get storageclass standard
+
+          # Checking env variable
+          if [[ "$KIND_REGISTRY" != "localhost:5000" ]]; then
+            echo "Wrong KIND_REGISTRY env variable: $KIND_REGISTRY"
+            exit 1
+          fi
+
+          # Test registry usage inside cluster
+          docker pull busybox
+          docker tag busybox localhost:5000/localbusybox
+          docker push localhost:5000/localbusybox
+
+          kubectl create job test --image=localhost:5000/localbusybox
+          i=1
+          max=60
+          while [[ $i -le $max ]] && [[ $(kubectl get pods -l job-name=test -o 'jsonpath={..status.phase}') != "Succeeded" ]]; do
+            echo "Waiting for pod to complete ($i/$max)..."
+            ((i++))
+            sleep 1
+          done
+          if [[ $i -ge $max ]]; then
+            echo "ERROR:  Pod did not complete!"
+            kubectl get pods -o yaml
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `cluster_name`: The name of the cluster to create (default: `chart-testing`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for kind
+- `registry`: Configures a registry on localhost:5000 to be used with kind (default: `false`)
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: box
 inputs:
   version:
-    description: "The kind version to use (default: v0.7.0)"
+    description: "The kind version to use (default: v0.8.1)"
   config:
     description: "The path to the kind config file"
   node_image:
@@ -17,6 +17,8 @@ inputs:
     description: "The duration to wait for the control plane to become ready (default: 60s)"
   log_level:
     description: "The log level for kind"
+  registry:
+    description: "Configures a registry on localhost:5000 to be used with kind (default: false)"
 runs:
   using: "node12"
   main: "main.js"

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -30,7 +30,12 @@ main() {
     fi
 
     kind delete cluster "${args[@]}"
+
+    registry_id=$(docker ps --filter "name=kind-registry" --format "{{.ID}}")
+    if [[ -n "$registry_id" ]]; then
+      echo "Deleting kind-registry..."
+      docker rm --force kind-registry
+    fi
 }
 
 main
-

--- a/main.sh
+++ b/main.sh
@@ -47,8 +47,18 @@ main() {
         args+=(--log-level "${INPUT_LOG_LEVEL}")
     fi
 
+
+    if [[ -n "${INPUT_REGISTRY:-}" ]] && [[ "${INPUT_REGISTRY,,}" = "true" ]]; then
+        "$SCRIPT_DIR/registry.sh" "${args[@]}"
+
+        if [[ -n "${INPUT_CONFIG:-}" ]]; then
+            echo 'WARNING: when using the "config" option, you need to manually configure the registry in the provided configuration'
+        else
+            args+=(--config "/etc/kind-registry/config.yaml")
+        fi
+    fi
+
     "$SCRIPT_DIR/kind.sh" "${args[@]}"
 }
 
 main
-

--- a/registry.sh
+++ b/registry.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DEFAULT_REGISTRY_IMAGE=registry:2
+DEFAULT_REGISTRY_NAME=kind-registry
+DEFAULT_REGISTRY_PORT=5000
+
+show_help() {
+cat << EOF
+Usage: $(basename "$0") <options>
+
+    -h, --help                              Display help
+        --registry-image                    The registry image to use (default: registry:2)
+        --registry-name                     The registry name to use
+        --registry-port                     The local port used to bind the registry
+
+EOF
+}
+
+main() {
+    local registry_image="$DEFAULT_REGISTRY_IMAGE"
+    local registry_name="$DEFAULT_REGISTRY_NAME"
+    local registry_port="$DEFAULT_REGISTRY_PORT"
+
+    parse_command_line "$@"
+
+    create_registry
+    connect_registry
+    create_kind_config
+
+}
+
+parse_command_line() {
+    while :; do
+        case "${1:-}" in
+            -h|--help)
+                show_help
+                exit
+                ;;
+            --registry-image)
+                if [[ -n "${2:-}" ]]; then
+                    registry_image="$2"
+                    shift
+                else
+                    echo "ERROR: '--registry-image' cannot be empty." >&2
+                    show_help
+                    exit 1
+                fi
+                ;;
+            --registry-name)
+                if [[ -n "${2:-}" ]]; then
+                    registry_name="$2"
+                    shift
+                else
+                    echo "ERROR: '--registry-name' cannot be empty." >&2
+                    show_help
+                    exit 1
+                fi
+                ;;
+            --registry-port)
+                if [[ -n "${2:-}" ]]; then
+                    registry_port="$2"
+                    shift
+                else
+                    echo "ERROR: '--registry-port' cannot be empty." >&2
+                    show_help
+                    exit 1
+                fi
+                ;;
+            *)
+                break
+                ;;
+        esac
+
+        shift
+    done
+}
+
+create_registry() {
+    echo "Creating registry \"$registry_name\" on port $registry_port from image \"$registry_image\"..."
+    docker run -d --restart=always -p "${registry_port}:5000" --name "${registry_name}" $registry_image > /dev/null
+    # Exporting the registry location for subsequent jobs
+    echo "KIND_REGISTRY=localhost:${registry_port}" >> $GITHUB_ENV
+}
+
+connect_registry() {
+    echo 'Connecting registry to the "kind" network...'
+    docker network create kind
+    docker network connect "kind" "${registry_name}"
+}
+
+create_kind_config() {
+    sudo mkdir -p /etc/kind-registry
+    cat <<EOF | sudo dd status=none of=/etc/kind-registry/config.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${registry_port}"]
+    endpoint = ["http://${registry_name}:${registry_port}"]
+EOF
+    sudo chmod a+r /etc/kind-registry/config.yaml
+}
+
+main "$@"


### PR DESCRIPTION
Really nice action!

There are many cases where I would like to leverage a local registry, e.g. when I need to build container images and run them on the cluster (in some cases, actually, I build container images from the cluster itself). So I've added an option to start a registry on "localhost:5000" that is also injected into the KinD config, so the cluster can see it on the same host.

I've followed the official recipe: https://kind.sigs.k8s.io/docs/user/local-registry/

Hope this can be merged into the action.