### PR TITLE
Resolve deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 
 - `version`: The kind version to use (default: `v0.11.1`)
 - `config`: The path to the kind config file
-- `node_image`: The Docker image for the cluster nodes
+- `node_image`: The Docker image for the cluster nodes (default: `v1.20.7`)
 - `cluster_name`: The name of the cluster to create (default: `chart-testing`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for kind

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `node_image`: The Docker image for the cluster nodes (default: `v1.20.7`)
 - `cluster_name`: The name of the cluster to create (default: `chart-testing`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
-- `log_level`: The log level for kind
+- `verbosity`: The verbosity level for kind (`int32`)
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   config:
     description: "The path to the kind config file"
   node_image:
-    description: "The Docker image for the cluster nodes"
+    description: "The Docker image for the cluster nodes (default: v1.20.7)"
   cluster_name:
     description: "The name of the cluster to create (default: chart-testing)"
   wait:

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: "The name of the cluster to create (default: chart-testing)"
   wait:
     description: "The duration to wait for the control plane to become ready (default: 60s)"
-  log_level:
-    description: "The log level for kind"
+  verbosity:
+    description: "The verbosity level for kind"
 runs:
   using: "node12"
   main: "main.js"

--- a/kind.sh
+++ b/kind.sh
@@ -21,6 +21,7 @@ set -o pipefail
 DEFAULT_KIND_VERSION=v0.11.1
 DEFAULT_CLUSTER_NAME=chart-testing
 KUBECTL_VERSION=v1.20.8
+DEFAULT_NODE_IMAGE=v1.20.7
 
 show_help() {
 cat << EOF
@@ -40,7 +41,7 @@ EOF
 main() {
     local version="$DEFAULT_KIND_VERSION"
     local config=
-    local node_image=
+    local node_image="$DEFAULT_NODE_IMAGE"
     local cluster_name="$DEFAULT_CLUSTER_NAME"
     local wait=60s
     local log_level=

--- a/kind.sh
+++ b/kind.sh
@@ -33,7 +33,7 @@ Usage: $(basename "$0") <options>
     -i, --node-image                        The Docker image for the cluster nodes"
     -n, --cluster-name                      The name of the cluster to create (default: chart-testing)"
     -w, --wait                              The duration to wait for the control plane to become ready (default: 60s)"
-    -l, --log-level                         The log level for kind [panic, fatal, error, warning, info, debug, trace] (default: warning)
+    -v                                      The verbosity level for kind (int32)
 
 EOF
 }
@@ -44,7 +44,7 @@ main() {
     local node_image="$DEFAULT_NODE_IMAGE"
     local cluster_name="$DEFAULT_CLUSTER_NAME"
     local wait=60s
-    local log_level=
+    local verbosity=
 
     parse_command_line "$@"
 
@@ -136,12 +136,12 @@ parse_command_line() {
                     exit 1
                 fi
                 ;;
-            -l|--log-level)
+            -v)
                 if [[ -n "${2:-}" ]]; then
-                    log_level="$2"
+                    verbosity="$2"
                     shift
                 else
-                    echo "ERROR: '--log-level' cannot be empty." >&2
+                    echo "ERROR: '-v' cannot be empty." >&2
                     show_help
                     exit 1
                 fi
@@ -185,8 +185,8 @@ create_kind_cluster() {
         args+=("--config=$config")
     fi
 
-    if [[ -n "$log_level" ]]; then
-        args+=("--loglevel=$log_level")
+    if [[ -n "$verbosity" ]]; then
+        args+=("-v=$verbosity")
     fi
 
     "$kind_dir/kind" "${args[@]}"

--- a/main.sh
+++ b/main.sh
@@ -43,8 +43,8 @@ main() {
         args+=(--wait "${INPUT_WAIT}")
     fi
 
-    if [[ -n "${INPUT_LOG_LEVEL:-}" ]]; then
-        args+=(--log-level "${INPUT_LOG_LEVEL}")
+    if [[ -n "${INPUT_VERBOSITY:-}" ]]; then
+        args+=(-v "${INPUT_VERBOSITY}")
     fi
 
     "$SCRIPT_DIR/kind.sh" "${args[@]}"


### PR DESCRIPTION
Resolved deprecation warning on log_level and updated node image to the corresponding `v1.20.7` compatible version.

See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1

resolves #39 

I could also isolate this deprecation solution into a separate PR.