### PR TITLE
allow to omit cluster creation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,3 +37,18 @@ jobs:
         run: |
           kubectl cluster-info
           kubectl get storageclass standard
+
+  test-with-install-only:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Only install kind without starting a cluster
+        uses: ./
+        with:
+          install_only: true
+
+      - name: Test kind works and there is no cluster started
+        run: |
+          [[ $(kind get clusters | wc -l) -eq 0 ]]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for kind
 - `kubectl_version`: The kubectl version to use (default: v1.20.8)
+- `install_only`: Skips cluster creation, only install kind (default: false)
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,8 @@ inputs:
     description: "The log level for kind"
   kubectl_version:
     description: "The kubectl version to use (default: v1.20.8)"
+  install_only:
+    description: "Skips cluster creation, only install kind (default: false)"
 runs:
   using: "node12"
   main: "main.js"

--- a/kind.sh
+++ b/kind.sh
@@ -27,13 +27,14 @@ cat << EOF
 Usage: $(basename "$0") <options>
 
     -h, --help                              Display help
-    -v, --version                           The kind version to use (default: $DEFAULT_KIND_VERSION)"
-    -c, --config                            The path to the kind config file"
-    -i, --node-image                        The Docker image for the cluster nodes"
-    -n, --cluster-name                      The name of the cluster to create (default: chart-testing)"
-    -w, --wait                              The duration to wait for the control plane to become ready (default: 60s)"
+    -v, --version                           The kind version to use (default: $DEFAULT_KIND_VERSION)
+    -c, --config                            The path to the kind config file
+    -i, --node-image                        The Docker image for the cluster nodes
+    -n, --cluster-name                      The name of the cluster to create (default: chart-testing)
+    -w, --wait                              The duration to wait for the control plane to become ready (default: 60s)
     -l, --log-level                         The log level for kind [panic, fatal, error, warning, info, debug, trace] (default: warning)
-    -k, --kubectl-version                   The kubectl version to use (default: $DEFAULT_KUBECTL_VERSION)"
+    -k, --kubectl-version                   The kubectl version to use (default: $DEFAULT_KUBECTL_VERSION)
+    -o, --install-only                      Skips cluster creation, only install kind (default: false)
 
 EOF
 }
@@ -46,6 +47,7 @@ main() {
     local wait=60s
     local log_level=
     local kubectl_version="$DEFAULT_KUBECTL_VERSION"
+    local install_only=false
 
     parse_command_line "$@"
 
@@ -77,7 +79,9 @@ main() {
     "$kind_dir/kind" version
     "$kubectl_dir/kubectl" version --client=true
 
-    create_kind_cluster
+    if [[ "$install_only" == false ]]; then
+      create_kind_cluster
+    fi
 }
 
 parse_command_line() {
@@ -155,6 +159,14 @@ parse_command_line() {
                     echo "ERROR: '-k|--kubectl-version' cannot be empty." >&2
                     show_help
                     exit 1
+                fi
+                ;;
+            -o|--install-only)
+                if [[ -n "${2:-}" ]]; then
+                    install_only="$2"
+                    shift
+                else
+                    install_only=true
                 fi
                 ;;
             *)

--- a/main.sh
+++ b/main.sh
@@ -51,8 +51,11 @@ main() {
         args+=(--kubectl-version "${INPUT_KUBECTL_VERSION}")
     fi
 
+    if [[ -n "${INPUT_INSTALL_ONLY:-}" ]]; then
+        args+=(--install-only)
+    fi
+
     "$SCRIPT_DIR/kind.sh" "${args[@]}"
 }
 
 main
-


### PR DESCRIPTION
In my pipeline, I'm creating a kind cluster with additional registry config as the following step, so during a build, I'm having two clusters created and it takes time. It would be nice to have the ability to just install kind without starting a cluster. That would save me around a minute on each build.