### PR TITLE
Support bash before v4.4

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -51,7 +51,7 @@ main() {
         args+=(--kubectl-version "${INPUT_KUBECTL_VERSION}")
     fi
 
-    "$SCRIPT_DIR/kind.sh" "${args[@]}"
+    "$SCRIPT_DIR/kind.sh" ${args[@]+"${args[@]}"}
 }
 
 main


### PR DESCRIPTION
Currently, kind-action does not work in an environment of having bash before 4.4(e.g. CentOS 7.9) with the following error.
```sh
... args[@]: unbound variable
```

This PR makes kind-action support bash before v4.4.

ref: https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u