### PR TITLE
Update kind.sh to allow arm runners

### DIFF
--- a/kind.sh
+++ b/kind.sh
@@ -55,7 +55,7 @@ main() {
     fi
 
     local arch
-    arch=$(uname -m)
+    arch=$(dpkg --print-architecture)
     local cache_dir="$RUNNER_TOOL_CACHE/kind/$version/$arch"
 
     local kind_dir="$cache_dir/kind/bin/"
@@ -171,7 +171,7 @@ install_kind() {
 
     mkdir -p "$kind_dir"
 
-    curl -sSLo "$kind_dir/kind" "https://github.com/kubernetes-sigs/kind/releases/download/$version/kind-linux-amd64"
+    curl -sSLo "$kind_dir/kind" "https://github.com/kubernetes-sigs/kind/releases/download/$version/kind-linux-$arch"
     chmod +x "$kind_dir/kind"
 }
 
@@ -180,7 +180,7 @@ install_kubectl() {
 
     mkdir -p "$kubectl_dir"
 
-    curl -sSLo "$kubectl_dir/kubectl" "https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl"
+    curl -sSLo "$kubectl_dir/kubectl" "https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/$arch/kubectl"
     chmod +x "$kubectl_dir/kubectl"
 }
 


### PR DESCRIPTION
As I explained in [the issue](https://github.com/helm/kind-action/issues/53), right now this action doesn't support arm archs, with this PR, ARM64 arch will be supported too