### PR TITLE
feat: bump default kind and kubectl versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 
 For more information on inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input)
 
-- `version`: The kind version to use (default: `v0.11.1`)
+- `version`: The kind version to use (default: `v0.12.0`)
 - `config`: The path to the kind config file
 - `node_image`: The Docker image for the cluster nodes
 - `cluster_name`: The name of the cluster to create (default: `chart-testing`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for kind
-- `kubectl_version`: The kubectl version to use (default: v1.20.8)
+- `kubectl_version`: The kubectl version to use (default: v1.23.4)
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: box
 inputs:
   version:
-    description: "The kind version to use (default: v0.11.1)"
+    description: "The kind version to use (default: v0.12.0)"
   config:
     description: "The path to the kind config file"
   node_image:
@@ -18,7 +18,7 @@ inputs:
   log_level:
     description: "The log level for kind"
   kubectl_version:
-    description: "The kubectl version to use (default: v1.20.8)"
+    description: "The kubectl version to use (default: v1.23.4)"
 runs:
   using: "node12"
   main: "main.js"

--- a/kind.sh
+++ b/kind.sh
@@ -18,9 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DEFAULT_KIND_VERSION=v0.11.1
+DEFAULT_KIND_VERSION=v0.12.0
 DEFAULT_CLUSTER_NAME=chart-testing
-DEFAULT_KUBECTL_VERSION=v1.20.8
+DEFAULT_KUBECTL_VERSION=v1.23.4
 
 show_help() {
 cat << EOF


### PR DESCRIPTION
Match latest kind release v0.12.0.

This version of kind defaults to Kubernetes 1.23, while kind v0.11.x defaulted to 1.21. Kubernetes 1.22 [removed a significant number of APIs](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22) so this change has the potential to cause breakage for users. I'm not sure if that is a problem, just wanted to note it in the PR.