### PR TITLE
Resolve `--log-level` deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `node_image`: The Docker image for the cluster nodes
 - `cluster_name`: The name of the cluster to create (default: `chart-testing`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
-- `log_level`: The log level for kind
+- `verbosity`: The verbosity level for kind
 - `kubectl_version`: The kubectl version to use (default: v1.20.8)
 
 ### Example Workflow

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: "The name of the cluster to create (default: chart-testing)"
   wait:
     description: "The duration to wait for the control plane to become ready (default: 60s)"
-  log_level:
-    description: "The log level for kind"
+  verbosity:
+    description: "The verbosity level for kind"
   kubectl_version:
     description: "The kubectl version to use (default: v1.20.8)"
 runs:

--- a/kind.sh
+++ b/kind.sh
@@ -32,7 +32,7 @@ Usage: $(basename "$0") <options>
     -i, --node-image                        The Docker image for the cluster nodes"
     -n, --cluster-name                      The name of the cluster to create (default: chart-testing)"
     -w, --wait                              The duration to wait for the control plane to become ready (default: 60s)"
-    -l, --log-level                         The log level for kind [panic, fatal, error, warning, info, debug, trace] (default: warning)
+    -v, --verbosity                         The log level for kind [panic, fatal, error, warning, info, debug, trace] (default: warning)
     -k, --kubectl-version                   The kubectl version to use (default: $DEFAULT_KUBECTL_VERSION)"
 
 EOF
@@ -44,7 +44,7 @@ main() {
     local node_image=
     local cluster_name="$DEFAULT_CLUSTER_NAME"
     local wait=60s
-    local log_level=
+    local verbosity=
     local kubectl_version="$DEFAULT_KUBECTL_VERSION"
 
     parse_command_line "$@"
@@ -137,12 +137,12 @@ parse_command_line() {
                     exit 1
                 fi
                 ;;
-            -l|--log-level)
+            -v|--verbosity)
                 if [[ -n "${2:-}" ]]; then
-                    log_level="$2"
+                    verbosity="$2"
                     shift
                 else
-                    echo "ERROR: '--log-level' cannot be empty." >&2
+                    echo "ERROR: '--verbosity' cannot be empty." >&2
                     show_help
                     exit 1
                 fi
@@ -196,8 +196,8 @@ create_kind_cluster() {
         args+=("--config=$config")
     fi
 
-    if [[ -n "$log_level" ]]; then
-        args+=("--loglevel=$log_level")
+    if [[ -n "$verbosity" ]]; then
+        args+=("--loglevel=$verbosity")
     fi
 
     "$kind_dir/kind" "${args[@]}"

--- a/main.sh
+++ b/main.sh
@@ -43,8 +43,8 @@ main() {
         args+=(--wait "${INPUT_WAIT}")
     fi
 
-    if [[ -n "${INPUT_LOG_LEVEL:-}" ]]; then
-        args+=(--log-level "${INPUT_LOG_LEVEL}")
+    if [[ -n "${INPUT_VERBOSITY:-}" ]]; then
+        args+=(--verbosity "${INPUT_VERBOSITY}")
     fi
 
     if [[ -n "${INPUT_KUBECTL_VERSION:-}" ]]; then


### PR DESCRIPTION
Hi - `kind` is not supporting `--log-level` anymore, actively refusing to set verbosity if the parameter is set with the previous syntax. 
I changed all occurrences to comply with the new `--verbosity` format.