### PR TITLE
feat(kind-version): change default kind version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ branding:
   icon: box
 inputs:
   version:
-    description: "The kind version to use (default: v0.12.0)"
+    description: "The kind version to use (default: v0.13.0)"
     required: false
-    default: "v0.12.0"
+    default: "v0.13.0"
   config:
     description: "The path to the kind config file"
     required: false


### PR DESCRIPTION
kind docker image of 1.24.X cannot boot using kind 0.12.0
As kind new version 0.13.0 is available, set default kind version to 0.13.0
#60