### PR TITLE
Fix arch detection in non-Debian distros

### DIFF
--- a/kind.sh
+++ b/kind.sh
@@ -58,10 +58,10 @@ main() {
 
     local arch
     case $(uname -m) in
-        i386)           arch="386" ;;
-        i686)           arch="386" ;;
-        x86_64)         arch="amd64" ;;
-        arm|aarch64)    dpkg --print-architecture | grep -q "arm64" && arch="arm64" || arch="arm" ;;
+        i386)               arch="386" ;;
+        i686)               arch="386" ;;
+        x86_64)             arch="amd64" ;;
+        arm|aarch64|arm64)  arch="arm64" ;;
     esac
     local cache_dir="${RUNNER_TOOL_CACHE}/kind/${version}/${arch}"
 


### PR DESCRIPTION
The current `arch` detection relies on `dpkg`, which is Debian-specific. My organization uses [self-hosted Github runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners), which are not based on Debian.

The script uses `arch` to download `kind` by filling the following URL template: `https://github.com/kubernetes-sigs/kind/releases/download/${version}/kind-linux-${arch}`. If you check [the assets in the latest kind version](https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0), the only available options are `amd64` and `arm64`, so the current logic to differentiate between `arm` and `arm64` is not needed. Therefore, I removed the `dpkg` command call with this PR.