### PR TITLE
chore: Bump node version to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,6 @@ inputs:
     default: false
     required: false
 runs:
-  using: "node16"
+  using: "node20"
   main: "main.js"
   post: "cleanup.js"


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.