### PR TITLE
feat: add custom kubeconfig option as action input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -103,6 +103,24 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
 
+  test-with-custom-kubeconfig:
+    runs-on: ubuntu-latest
+    env:
+      KUBECONFIG: "./kubeconfig"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Create kind cluster with custom kubeconfig
+        uses: ./
+        with:
+          kubeconfig: "${{ env.KUBECONFIG }}"
+          cluster_name: "kube-config-test"
+
+      - name: Test
+        run: |
+          grep "kube-config-test" ${KUBECONFIG}
+
   test-with-custom-kubectl-version:
     runs-on: ubuntu-latest
     steps:

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   config:
     description: "The path to the kind config file"
     required: false
+  kubeconfig:
+    description: "The path to the kubeconfig config file"
+    required: false
   node_image:
     description: "The Docker image for the cluster nodes"
     required: false

--- a/kind.sh
+++ b/kind.sh
@@ -29,6 +29,7 @@ Usage: $(basename "$0") <options>
         --help                              Display help
     -v, --version                           The kind version to use (default: $DEFAULT_KIND_VERSION)
     -c, --config                            The path to the kind config file
+    -K, --kubeconfig                        The path to the kubeconfig config file
     -i, --node-image                        The Docker image for the cluster nodes
     -n, --cluster-name                      The name of the cluster to create (default: chart-testing)
     -w, --wait                              The duration to wait for the control plane to become ready (default: 60s)
@@ -42,6 +43,7 @@ EOF
 main() {
     local version="${DEFAULT_KIND_VERSION}"
     local config=
+    local kubeconfig=
     local node_image=
     local cluster_name="${DEFAULT_CLUSTER_NAME}"
     local wait=60s
@@ -113,6 +115,16 @@ parse_command_line() {
                     shift
                 else
                     echo "ERROR: '--config' cannot be empty." >&2
+                    show_help
+                    exit 1
+                fi
+                ;;
+            -K|--kubeconfig)
+                if [[ -n "${2:-}" ]]; then
+                    kubeconfig="$2"
+                    shift
+                else
+                    echo "ERROR: '--kubeconfig' cannot be empty." >&2
                     show_help
                     exit 1
                 fi
@@ -218,6 +230,10 @@ create_kind_cluster() {
 
     if [[ -n "${config}" ]]; then
         args+=("--config=${config}")
+    fi
+
+    if [[ -n "${kubeconfig}" ]]; then
+        args+=("--kubeconfig=${kubeconfig}")
     fi
 
     if [[ -n "${verbosity}" ]]; then

--- a/main.sh
+++ b/main.sh
@@ -31,6 +31,10 @@ main() {
         args+=(--config "${INPUT_CONFIG}")
     fi
 
+    if [[ -n "${INPUT_KUBECONFIG:-}" ]]; then
+        args+=(--kubeconfig "${INPUT_KUBECONFIG}")
+    fi
+
     if [[ -n "${INPUT_NODE_IMAGE:-}" ]]; then
         args+=(--node-image "${INPUT_NODE_IMAGE}")
     fi


### PR DESCRIPTION
Adding the custom `kubeconfig` option to pass it as an action input allows anyone to specify a certain `KUBECONFIG` environment variable to be used along the entire workflow job.

E.G.:  I had to create a `kind` cluster to run some commands. This command requires the `$KUBECONFIG` to contain the actual kubernetes config path. With this patch I'm allowed to export the variable required to the next steps with certainty that I'm using the right kubernetes config.
