### PR TITLE
Load GITHUB_PATH in PATH to use correct binaries when creating registry

### DIFF
--- a/registry.sh
+++ b/registry.sh
@@ -140,6 +140,12 @@ connect_registry() {
 }
 
 config_registry_for_nodes() {
+    if [ -f "$GITHUB_PATH" ]; then
+        while IFS= read -r line; do
+            export PATH="$line:$PATH"
+        done < "$GITHUB_PATH"
+    fi
+
     # Reference: https://github.com/containerd/containerd/blob/main/docs/hosts.md
     REGISTRY_DIR="/etc/containerd/certs.d/${registry_name}:${registry_port}"
 


### PR DESCRIPTION
When `kind.sh` installs 'kubectl' and 'kind', they are put in `GITHUB_PATH` which makes them discoverable for the next steps in the pipeline, but not for other scripts in the same step, like `registry.sh` for example.

The reason it currently works is that 'kubectl' and 'kind' are [already present](https://github.com/actions/runner-images/blob/ubuntu24/20250126.1/images/ubuntu/Ubuntu2404-Readme.md#tools) in Github Action's image. This means that regardless what the actions installs, `registry.sh` will always use the versions provided by the GH runner. 

The version mismatch can potentially cause some issues when running in Github Actions, but completely breaks the pipeline when using local runner like `nektos/act` where 'kubectl' might not exist in the first place 

[Here](https://github.com/gotha/kind-action/pull/3/files) is a more verbose debugging version of this PR that shows what binaries are used at each stage where you can see that when `registry.sh` starts `which -a kubectl` reports:
```sh
/usr/bin/kubectl
/bin/kubectl
```
and after `GITHUB_PATH` is loaded 
```sh
/opt/hostedtoolcache/kind/v0.26.0/amd64/kubectl/bin//kubectl
/usr/bin/kubectl
/bin/kubectl
```

The approach in this PR is just one way to do it. I am looking for comments and suggestions on what would be a better way to fix the issue (or even if you consider it an issue at all). 