### PR TITLE
feat: Add cloud provider

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -258,4 +258,23 @@ jobs:
             
             curl -X DELETE $LOCAL_REGISTRY/v2/localbusybox/manifests/$DIGEST
             [[ "$(curl -Ls $LOCAL_REGISTRY/v2/localbusybox/tags/list | jq .tags)" == null ]]
-            
+
+  test-with-cloud-provider-enabled:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+        - name: Create kind cluster with cloud provider
+          uses: ./
+          with:
+            cloud_provider: true
+
+        - name: Test
+          run: |
+            if ps aux | grep -v grep | grep cloud-provider-kind; then
+              echo "Cloud provider is present."
+            else
+              echo "Cloud provider is not present."
+              exit 1
+            fi        

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `registry_enable_delete`: Enable delete operations on the registry (default: false)
 - `install_only`: Skips cluster creation, only install kind (default: false)
 - `ignore_failed_clean`: Whether to ignore the post delete cluster action failing (default: false)
+- `cloud_provider`: Whether to use cloud provider loadbalancer (default: false)
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: "Whether to ignore the post-delete the cluster (default: false)"
     default: "false"
     required: false
+  cloud_provider:
+    description: "Whether to use cloud provider loadbalancer (default: false)"
+    required: false
+    default: "false"
 runs:
   using: "node20"
   main: "main.js"

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -25,6 +25,13 @@ main() {
     args=(--name "${INPUT_CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}")
     registry_args=("${INPUT_REGISTRY_NAME:-$DEFAULT_REGISTRY_NAME}")
 
+    if [[ "${INPUT_CLOUD_PROVIDER:-false}" == true ]]; then
+        rm -f /usr/local/bin/cloud-provider-kind || true
+        rm -rf cloud-provider-kind || true
+        rm -f /tmp/cloud-provider.log || true
+        rm -f cloud-provider-kind_*_checksums.txt || true
+    fi
+
     docker rm -f "${registry_args[@]}" || "${INPUT_IGNORE_FAILED_CLEAN}"
     
     kind delete cluster "${args[@]}" || "${INPUT_IGNORE_FAILED_CLEAN}"

--- a/main.sh
+++ b/main.sh
@@ -81,6 +81,10 @@ main() {
         registry_args+=(--enable-delete "${INPUT_REGISTRY_ENABLE_DELETE}")
     fi
 
+    if [[ -n "${INPUT_CLOUD_PROVIDER:-}" ]]; then
+        args+=(--cloud-provider "${INPUT_CLOUD_PROVIDER}")
+    fi
+
     "${SCRIPT_DIR}/kind.sh" ${args[@]+"${args[@]}"}
 
     if [[ "${INPUT_REGISTRY:-}" == true ]]; then


### PR DESCRIPTION
Adding the custom `cloud_provider` option to enable a LoadBalancer along with start of the cluster.

This change enables the installation of an additional `cloud-provider-kind` component when the option is activated. 
Services requiring a LoadBalancer will now function as expected.