### PR TITLE
bug: respect 'install_only' action input value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,7 @@ inputs:
     default: "false"
   install_only:
     description: "Skips cluster creation, only install kind (default: false)"
+    default: "false"
     required: false
   ignore_failed_clean:
     description: "Whether to ignore the post-delete the cluster (default: false)"

--- a/main.sh
+++ b/main.sh
@@ -58,7 +58,7 @@ main() {
     fi
 
     if [[ -n "${INPUT_INSTALL_ONLY:-}" ]]; then
-        args+=(--install-only)
+        args+=(--install-only "${INPUT_INSTALL_ONLY}")
     fi
 
     if [[ -n "${INPUT_REGISTRY:-}" ]]; then


### PR DESCRIPTION
**Description**

Currently, the `install_only` argument is not taken into account. As a result, the install is always skipped whenever `install_only` is set, even if it is set to `install_only: false`.

This PR fix that in the same way as e.g. the `registry: true` is handled.