### PR TITLE
fix: propagate registry_port to container and containerd

### DIFF
--- a/registry.sh
+++ b/registry.sh
@@ -122,7 +122,8 @@ create_registry() {
     docker run -d --restart=always \
         --name "${registry_name}" \
         --network bridge \
-        -p "${registry_port}:5000" \
+        -p "${registry_port}:${registry_port}" \
+        -e REGISTRY_HTTP_ADDR="0.0.0.0:${registry_port}" \
         -e REGISTRY_STORAGE_DELETE_ENABLED="$enable_delete" \
         $registry_image
 
@@ -152,7 +153,7 @@ config_registry_for_nodes() {
     for node in $(kind get nodes -n "${cluster_name}"); do
         docker exec "${node}" mkdir -p "${REGISTRY_DIR}"
         cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
-[host."http://${registry_name}:5000"]
+[host."http://${registry_name}:${registry_port}"]
 EOF
     done
 }


### PR DESCRIPTION
When using a non-default `registry_port` (e.g. 5555), the registry container still listened on port 5000 internally. The Docker port mapping (`5555:5000`) only worked from the host but not from within the Kind network, so pods could not pull images using the configured port.

**Root cause:**
- `docker run -p ${registry_port}:5000` mapped the host port but the container always bound to 5000
- `hosts.toml` had port 5000 hardcoded instead of using `${registry_port}`

**Fix:**
- Set `REGISTRY_HTTP_ADDR=0.0.0.0:${registry_port}` so the registry binds on the configured port
- Map the same port on both sides: `-p ${registry_port}:${registry_port}`
- Use `${registry_port}` in `hosts.toml` instead of hardcoded 5000

**Tested with:**
- Custom port 5555: pods successfully pull images from `kind-registry:5555`
- Default port 5000: no regression, works as before

Fixes #143