### PR TITLE
feat: add version_file input to read the kind version from a file

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -140,6 +140,32 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
 
+  test-with-version-file:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Create version file
+        run: echo "kind v0.23.0" > .tool-versions
+
+      - name: Create kind cluster from version file
+        uses: ./
+        with:
+          version_file: ".tool-versions"
+
+      - name: Test
+        run: |
+          kind version | grep "v0.23.0"
+          kubectl cluster-info
+          kubectl get nodes
+
   test-with-custom-kubeconfig:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 For more information on inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input)
 
 - `version`: The kind version to use (default: `v0.31.0`)
+- `version_file`: The path to a file containing the kind version to use. Supports the asdf [`.tool-versions`](https://asdf-vm.com/manage/configuration.html#tool-versions) layout (the `kind` entry) and plain version files. The version is used as-is, so include the leading `v` (for example `kind v0.31.0`). Takes precedence over `version` when set.
 - `config`: The path to the kind config file
 - `node_image`: The Docker image for the cluster nodes
 - `cluster_name`: The name of the cluster to create (default: `chart-testing`)

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: "The kind version to use (default: v0.31.0)"
     required: false
     default: "v0.31.0"
+  version_file:
+    description: "The path to a file containing the kind version to use (asdf '.tool-versions' or a plain version file; the version is used as-is, e.g. v0.31.0). Takes precedence over 'version' when set."
+    required: false
   config:
     description: "The path to the kind config file"
     required: false

--- a/main.sh
+++ b/main.sh
@@ -20,9 +20,44 @@ set -o pipefail
 
 SCRIPT_DIR=$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" || realpath "${BASH_SOURCE[0]}")")
 
+# Resolve the kind version from a version file. Supports the asdf
+# '.tool-versions' format (a line such as "kind v0.31.0") as well as a plain
+# file that contains only the version string.
+resolve_version_from_file() {
+    local file="$1"
+    local version=""
+
+    if [[ ! -f "${file}" ]]; then
+        echo "ERROR: version_file '${file}' does not exist." >&2
+        exit 1
+    fi
+
+    # asdf '.tool-versions' format: a line such as "kind v0.31.0".
+    version=$(grep -E '^[[:space:]]*kind[[:space:]]+' "${file}" | head -n 1 | tr -d '\r' | awk '{print $2}') || true
+
+    # Otherwise treat the file as a plain version file (first token of the
+    # first non-empty, non-comment line).
+    if [[ -z "${version}" ]]; then
+        version=$(grep -vE '^[[:space:]]*(#|$)' "${file}" | head -n 1 | tr -d '\r' | awk '{print $1}') || true
+    fi
+
+    if [[ -z "${version}" ]]; then
+        echo "ERROR: no kind version found in version_file '${file}'." >&2
+        exit 1
+    fi
+
+    echo "${version}"
+}
+
 main() {
     local args=()
     local registry_args=()
+
+    # A version file takes precedence over the 'version' input when set.
+    if [[ -n "${INPUT_VERSION_FILE:-}" ]]; then
+        INPUT_VERSION="$(resolve_version_from_file "${INPUT_VERSION_FILE}")"
+        echo "Using kind version '${INPUT_VERSION}' from version_file '${INPUT_VERSION_FILE}'." >&2
+    fi
 
     if [[ -n "${INPUT_VERSION:-}" ]]; then
         args+=(--version "${INPUT_VERSION}")


### PR DESCRIPTION
Adds a `version_file` input that reads the kind version from a file, so the
version can live in a single source of truth (for example an asdf
`.tool-versions` file) instead of being hard-coded in the workflow.

- Supports the asdf `.tool-versions` layout (the `kind` entry) and plain
  version files.
- The version is used as-is (include the leading `v`, e.g. `v0.31.0`),
  consistent with the existing `version` input.
- When both are set, `version_file` takes precedence over `version`.

## Validation

- Added a `test-with-version-file` job that writes `kind v0.23.0` to a
  `.tool-versions` file and asserts the installed kind version is `v0.23.0`
  (the action default is `v0.31.0`, so the assertion proves the file drove
  the install).
- Unit-tested the resolver against: asdf multi-tool file, plain version file,
  comment/blank-line file, extra whitespace, CRLF endings, multi-token line,
  missing file, empty file.
- `bash -n main.sh` passes.

---

This PR was prepared with AI assistance (Claude Code). All changes were
reviewed and tested by me before submission.