### PR TITLE
Report url that could not be downloaded

### DIFF
--- a/kind.sh
+++ b/kind.sh
@@ -218,14 +218,23 @@ parse_command_line() {
     done
 }
 
+call_curl() {
+    if curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o "$1" "$2"; then
+        :
+    else
+        error="$?"
+        error="$error" url="$2" sh -c 'echo "Failed to download \"$url\""; exit $error'
+    fi
+}
+
 install_kind() {
     echo 'Installing kind...'
 
     mkdir -p "${kind_dir}"
 
     pushd "${kind_dir}"
-    curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o "kind-linux-${arch}" "https://github.com/kubernetes-sigs/kind/releases/download/${version}/kind-linux-${arch}"
-    curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o "kind-linux-${arch}.sha256sum" "https://github.com/kubernetes-sigs/kind/releases/download/${version}/kind-linux-${arch}.sha256sum"
+    call_curl "kind-linux-${arch}" "https://github.com/kubernetes-sigs/kind/releases/download/${version}/kind-linux-${arch}"
+    call_curl "kind-linux-${arch}.sha256sum" "https://github.com/kubernetes-sigs/kind/releases/download/${version}/kind-linux-${arch}.sha256sum"
     grep "kind-linux-${arch}" < "kind-linux-${arch}.sha256sum" | sha256sum -c
     mv "kind-linux-${arch}" kind
     rm -f "kind-linux-${arch}.sha256sum"
@@ -239,8 +248,8 @@ install_kubectl() {
     mkdir -p "${kubectl_dir}"
 
     pushd "${kubectl_dir}"
-    curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o kubectl "https://dl.k8s.io/release/${kubectl_version}/bin/linux/${arch}/kubectl"
-    curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o kubectl.sha256 "https://dl.k8s.io/release/${kubectl_version}/bin/linux/${arch}/kubectl.sha256"
+    call_curl kubectl "https://dl.k8s.io/release/${kubectl_version}/bin/linux/${arch}/kubectl"
+    call_curl kubectl.sha256 "https://dl.k8s.io/release/${kubectl_version}/bin/linux/${arch}/kubectl.sha256"
     echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
     chmod +x kubectl
     popd
@@ -262,8 +271,8 @@ EOF
 
 install_cloud_provider(){
     echo "Setting up cloud-provider-kind..."
-    curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_linux_amd64.tar.gz https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/v${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}/cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_linux_amd64.tar.gz > /dev/null 2>&1
-    curl -sSL --retry 5 --retry-all-errors --retry-delay 5 -o cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_checksums.txt https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/v${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}/cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_checksums.txt
+    call_curl cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_linux_amd64.tar.gz https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/v${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}/cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_linux_amd64.tar.gz > /dev/null 2>&1
+    call_curl cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_checksums.txt https://github.com/kubernetes-sigs/cloud-provider-kind/releases/download/v${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}/cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_checksums.txt
 
     grep "cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_linux_amd64.tar.gz" < "cloud-provider-kind_${DEFAULT_CLOUD_PROVIDER_KIND_VERSION}_checksums.txt" | sha256sum -c
 


### PR DESCRIPTION
We saw this:
```yaml
Run helm/kind-action@v1.14.0
    with:
      cluster_name: e2e-tests
      kubectl_version: v1.33.5
      config: config.yml
      version: v0.31.0
      wait: 60s
      verbosity: 0
      registry: false
      registry_image: registry:2
      registry_name: kind-registry
      registry_port: 5000
      registry_enable_delete: false
      install_only: false
      ignore_failed_clean: false
      cloud_provider: false

  Installing kind...
  /opt/hostedtoolcache/kind/v0.31.0/amd64/kind/bin ~/work/repository-name/repository-name
  curl: (56) Connection died, tried 5 times before giving up
```

Unfortunately, we can't really tell _what_ failed to download. I think people would benefit from knowing which failed download caused the action to fail, as there are 6 different things that might download, and failing any one of them would be fatal: https://github.com/helm/kind-action/blob/c72b4750145dbfb1c71734c3782a4db35a1c65c0/kind.sh#L17